### PR TITLE
specify ffmpeg version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
 
       - uses: FedericoCarboni/setup-ffmpeg@v3
         id: setup-ffmpeg
+        with:
+          ffmpeg-version: 7.0.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
It looks like occasional errors with ffmpeg installation can be prevented by pinning the ffmpeg version. Let's try this and see if the errors go away.

Ref: https://github.com/federicocarboni/setup-ffmpeg/issues/20

