### PR TITLE
exclude `tests` and `assets` directories

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["src/waddle"]
 
+[tool.hatch.build.targets.sdist]
+exclude = ["tests", "assets"]
+
 [project.scripts]
 waddle = "waddle.__main__:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ build-backend = "hatchling.build"
 packages = ["src/waddle"]
 
 [tool.hatch.build.targets.sdist]
-exclude = ["tests", "assets"]
+exclude = ["tests", "assets", "htmlcov"]
 
 [project.scripts]
 waddle = "waddle.__main__:main"


### PR DESCRIPTION
By default, `hatchling` includes everything except for files in the root gitignore. This means the large gif in `assets` and test files are included in the package. In addition, the `htmlcov` directory is not tracked on git because it has ".gitignore" inside, but since `hatchling` only reads the root gitignore, `htmlcov` can be included in the package if the directory exists. This PR instructs `hatchling` to exclude the three directories during packaging, reducing the bundle size from 5.4 MB to 50 KB.