### PR TITLE
use fork to retry ffmpeg installation in case of error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: FedericoCarboni/setup-ffmpeg@v3
+      - uses: emptymap/setup-ffmpeg@5644f1ea8a58c026223ed8d5147314e7fb7ae3ba
         id: setup-ffmpeg
         with:
           ffmpeg-version: 7.0.2


### PR DESCRIPTION
This PR switches the `setup-ffmpeg` action to our fork (emptymap/setup-ffmpeg), which retries HTTP requests in case of an error. I want to try this for a while to see if this fixes the occasional error.

https://github.com/emptymap/setup-ffmpeg/commit/4f39b006d1fbcbcad45ea77501de7d6ab4bee043