### PR TITLE
use `user_runtime_dir` to save tools

### DIFF
--- a/src/waddle/audios/call_tools.py
+++ b/src/waddle/audios/call_tools.py
@@ -3,7 +3,7 @@ import subprocess
 import threading
 from pathlib import Path
 
-from platformdirs import user_data_dir
+from platformdirs import user_runtime_dir
 
 from waddle.config import APP_AUTHOR, APP_NAME, DEFAULT_LANGUAGE
 from waddle.tools.install_deep_filter import install_deep_filter
@@ -14,7 +14,7 @@ def get_tools_dir() -> Path:
     """
     Get the tools directory.
     """
-    return Path(user_data_dir(APP_NAME, APP_AUTHOR)) / "tools"
+    return Path(user_runtime_dir(APP_NAME, APP_AUTHOR)) / "tools"
 
 
 def convert_to_wav(input_path: Path, output_path_or_none: Path | None = None) -> None:

--- a/src/waddle/tools/install_deep_filter.py
+++ b/src/waddle/tools/install_deep_filter.py
@@ -3,14 +3,14 @@ import sys
 import urllib.request
 from pathlib import Path
 
-from platformdirs import user_data_dir
+from platformdirs import user_runtime_dir
 
 from waddle.config import APP_AUTHOR, APP_NAME
 
 
 def install_deep_filter():
     # Tool installation directories
-    TOOLS_DIR = Path(user_data_dir(APP_NAME, APP_AUTHOR)) / "tools"
+    TOOLS_DIR = Path(user_runtime_dir(APP_NAME, APP_AUTHOR)) / "tools"
     DEEP_FILTER_OUTPUT = TOOLS_DIR / "deep-filter"
     if DEEP_FILTER_OUTPUT.exists():
         print(f"DeepFilterNet binary already exists: {DEEP_FILTER_OUTPUT}")

--- a/src/waddle/tools/install_whisper_cpp.py
+++ b/src/waddle/tools/install_whisper_cpp.py
@@ -2,14 +2,14 @@ import os
 import subprocess
 from pathlib import Path
 
-from platformdirs import user_data_dir
+from platformdirs import user_runtime_dir
 
 from waddle.config import APP_AUTHOR, APP_NAME
 
 
 def install_whisper_cpp():
     # Tool installation directories
-    TOOLS_DIR = Path(user_data_dir(APP_NAME, APP_AUTHOR)) / "tools"
+    TOOLS_DIR = Path(user_runtime_dir(APP_NAME, APP_AUTHOR)) / "tools"
     WHISPER_DIR = TOOLS_DIR / "whisper.cpp"
 
     # Create the tools directory if it doesn't exist
@@ -22,6 +22,7 @@ def install_whisper_cpp():
             ["git", "clone", "https://github.com/ggerganov/whisper.cpp.git", str(WHISPER_DIR)],
             check=True,
         )
+        subprocess.run(["git", "checkout", "v1.7.4"], check=True, cwd=str(WHISPER_DIR))
     else:
         print(f"whisper.cpp already exists at {WHISPER_DIR}")
 


### PR DESCRIPTION
It appears that we can't use the metal backend if we place `whisper.cpp` inside `~/Library/Application Support` on Mac. This is likely due to Apple's sandboxing, but I'm not entirely sure. This PR changes the tools directory to `user_runtime_dir` (`/Users/{user}/Library/Caches/TemporaryItems`).