### PR TITLE
Call whisper in batches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           uv run pytest --cov=src --junitxml=junit.xml -o junit_family=legacy --cov-report "xml:coverage.xml" --cov-report=term-missing --cov-config=pyproject.toml
         env:
-          WHISPER_MODEL_NAME: "base"
+          WHISPER_MODEL_NAME: "tiny"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           uv run pytest --cov=src --junitxml=junit.xml -o junit_family=legacy --cov-report "xml:coverage.xml" --cov-report=term-missing --cov-config=pyproject.toml
         env:
-          WHISPER_MODEL_NAME: "tiny"
+          WHISPER_MODEL_NAME: "base"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/src/waddle/audios/call_tools.py
+++ b/src/waddle/audios/call_tools.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import tempfile
 import threading
 from pathlib import Path
 
@@ -128,6 +129,69 @@ def remove_noise(input_path: Path, output_path: Path) -> None:
 
 
 whisper_install_lock = threading.Lock()
+
+
+def transcribe_in_batches(
+    input_output_paths: list[tuple[Path, Path]],
+    options: str = f"-l {DEFAULT_LANGUAGE}",
+    *,
+    batch_size: int = 200,
+) -> None:
+    """
+    Transcribe audio in batches using Whisper.cpp.
+    """
+
+    # Paths
+    tools_dir = get_tools_dir()
+    whisper_bin = tools_dir / "whisper.cpp" / "build" / "bin" / "whisper-cli"
+    whisper_model = (
+        tools_dir
+        / "whisper.cpp"
+        / "models"
+        / f"ggml-{os.getenv('WHISPER_MODEL_NAME') or 'large-v3'}.bin"
+    )
+
+    # Check if the Whisper binary exists
+    with whisper_install_lock:
+        if not whisper_model.exists():
+            install_whisper_cpp()
+
+    # Check if the Whisper model exists
+    if not whisper_model.exists():
+        raise FileNotFoundError(f"Whisper model not found. Please ensure {whisper_model} exists.")
+
+    # List of pairs of tmp audio paths and output paths
+    tmp_output_paths = []
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for input_path, output_path in input_output_paths:
+            # Ensure input is 16kHz and 16-bit
+            tmp_audio_path = Path(temp_dir) / input_path.name
+            ensure_sampling_rate(input_path, tmp_audio_path, target_rate=16000)
+            tmp_output_paths.append((tmp_audio_path, output_path))
+
+        batches = [
+            tmp_output_paths[i : i + batch_size]
+            for i in range(0, len(tmp_output_paths), batch_size)
+        ]
+
+        for batch in batches:
+            command = [
+                str(whisper_bin),
+                "-m",
+                str(whisper_model),
+                *options.split(),
+                "-osrt",
+            ]
+            for temp_audio_path, output_path in batch:
+                command.extend([str(temp_audio_path), "-of", str(output_path)])
+            try:
+                subprocess.run(
+                    command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                )
+                for _, output_path in batch:
+                    Path(f"{output_path}.srt").replace(output_path)
+            except subprocess.CalledProcessError as e:
+                raise RuntimeError(f"[ERROR] Running Whisper: {e}") from e
 
 
 def transcribe(

--- a/src/waddle/audios/call_tools_test.py
+++ b/src/waddle/audios/call_tools_test.py
@@ -371,7 +371,7 @@ def test_transcribe_in_batches_1():
 
         for _, output_path in input_output_paths:
             assert output_path.exists()
-            assert len(list(output_path.read_text().strip().split("\n"))) > 3
+            assert len(output_path.read_text().strip().split("\n")) > 3
 
 
 def test_transcribe_in_batches_2():
@@ -393,4 +393,4 @@ def test_transcribe_in_batches_2():
 
         for _, output_path in input_output_paths:
             assert output_path.exists()
-            assert len(list(output_path.read_text().strip().split("\n"))) > 3
+            assert len(output_path.read_text().strip().split("\n")) > 3

--- a/src/waddle/audios/call_tools_test.py
+++ b/src/waddle/audios/call_tools_test.py
@@ -367,7 +367,7 @@ def test_transcribe_in_batches_1():
             shutil.copy(wav_file_path, temp_wav_path)
             input_output_paths.append((temp_wav_path, temp_dir_path / f"transcription_{i}.txt"))
 
-        transcribe_in_batches(input_output_paths, batch_size=2)
+        transcribe_in_batches(input_output_paths, "-l ja -tp 0", batch_size=2)
 
         for _, output_path in input_output_paths:
             assert output_path.exists()
@@ -389,7 +389,7 @@ def test_transcribe_in_batches_2():
             input_output_paths.append((temp_wav_path, temp_dir_path / f"transcription_{i}.txt"))
 
         # batch_size > len(input_output_paths)
-        transcribe_in_batches(input_output_paths, batch_size=5)
+        transcribe_in_batches(input_output_paths, "-l ja -tp 0", batch_size=5)
 
         for _, output_path in input_output_paths:
             assert output_path.exists()

--- a/src/waddle/audios/call_tools_test.py
+++ b/src/waddle/audios/call_tools_test.py
@@ -367,7 +367,7 @@ def test_transcribe_in_batches_1():
             shutil.copy(wav_file_path, temp_wav_path)
             input_output_paths.append((temp_wav_path, temp_dir_path / f"transcription_{i}.txt"))
 
-        transcribe_in_batches(input_output_paths, "-l ja -tp 0", batch_size=2)
+        transcribe_in_batches(input_output_paths, batch_size=2)
 
         for _, output_path in input_output_paths:
             assert output_path.exists()
@@ -389,7 +389,7 @@ def test_transcribe_in_batches_2():
             input_output_paths.append((temp_wav_path, temp_dir_path / f"transcription_{i}.txt"))
 
         # batch_size > len(input_output_paths)
-        transcribe_in_batches(input_output_paths, "-l ja -tp 0", batch_size=5)
+        transcribe_in_batches(input_output_paths, batch_size=5)
 
         for _, output_path in input_output_paths:
             assert output_path.exists()

--- a/src/waddle/audios/call_tools_test.py
+++ b/src/waddle/audios/call_tools_test.py
@@ -371,7 +371,7 @@ def test_transcribe_in_batches_1():
 
         for _, output_path in input_output_paths:
             assert output_path.exists()
-            assert len(output_path.read_text().strip().split("\n")) > 3
+            assert len(list(output_path.read_text().strip().split("\n"))) > 3
 
 
 def test_transcribe_in_batches_2():
@@ -393,4 +393,4 @@ def test_transcribe_in_batches_2():
 
         for _, output_path in input_output_paths:
             assert output_path.exists()
-            assert len(output_path.read_text().strip().split("\n")) > 3
+            assert len(list(output_path.read_text().strip().split("\n"))) > 3

--- a/src/waddle/audios/call_tools_test.py
+++ b/src/waddle/audios/call_tools_test.py
@@ -1,3 +1,4 @@
+import shutil
 import subprocess
 import tempfile
 import wave
@@ -13,6 +14,7 @@ from waddle.audios.call_tools import (
     ensure_sampling_rate,
     remove_noise,
     transcribe,
+    transcribe_in_batches,
 )
 
 # Define test directory paths
@@ -349,3 +351,46 @@ def test_transcribe_error():
         with subprocess_run_with_error("whisper"):
             with pytest.raises(RuntimeError, match="Running Whisper"):
                 transcribe(temp_wav_path, output_txt)
+
+
+def test_transcribe_in_batches_1():
+    """Test transcription in batches using Whisper."""
+    wav_file_path = EP0_DIR_PATH / "ep12-masa.wav"
+    if not wav_file_path.exists():
+        pytest.skip(f"Sample file {wav_file_path} not found")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_path = Path(temp_dir)
+        input_output_paths = []
+        for i in range(5):
+            temp_wav_path = temp_dir_path / f"audio_{i}.wav"
+            shutil.copy(wav_file_path, temp_wav_path)
+            input_output_paths.append((temp_wav_path, temp_dir_path / f"transcription_{i}.txt"))
+
+        transcribe_in_batches(input_output_paths, batch_size=2)
+
+        for _, output_path in input_output_paths:
+            assert output_path.exists()
+            assert len(output_path.read_text().strip().split("\n")) > 3
+
+
+def test_transcribe_in_batches_2():
+    """Test transcription in batches using Whisper."""
+    wav_file_path = EP0_DIR_PATH / "ep12-masa.wav"
+    if not wav_file_path.exists():
+        pytest.skip(f"Sample file {wav_file_path} not found")
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_dir_path = Path(temp_dir)
+        input_output_paths = []
+        for i in range(2):
+            temp_wav_path = temp_dir_path / f"audio_{i}.wav"
+            shutil.copy(wav_file_path, temp_wav_path)
+            input_output_paths.append((temp_wav_path, temp_dir_path / f"transcription_{i}.txt"))
+
+        # batch_size > len(input_output_paths)
+        transcribe_in_batches(input_output_paths, batch_size=5)
+
+        for _, output_path in input_output_paths:
+            assert output_path.exists()
+            assert len(output_path.read_text().strip().split("\n")) > 3

--- a/src/waddle/audios/call_tools_test.py
+++ b/src/waddle/audios/call_tools_test.py
@@ -321,7 +321,7 @@ def test_transcribe():
         transcribe(temp_wav_path, output_txt)
 
         assert output_txt.exists()
-        assert len(output_txt.read_text().strip().split("\n")) > 3
+        assert len(output_txt.read_text().strip().split("\n")) >= 3
 
 
 def test_transcribe_file_not_found():
@@ -371,7 +371,7 @@ def test_transcribe_in_batches_1():
 
         for _, output_path in input_output_paths:
             assert output_path.exists()
-            assert len(output_path.read_text().strip().split("\n")) > 3
+            assert len(output_path.read_text().strip().split("\n")) >= 3
 
 
 def test_transcribe_in_batches_2():
@@ -393,4 +393,4 @@ def test_transcribe_in_batches_2():
 
         for _, output_path in input_output_paths:
             assert output_path.exists()
-            assert len(output_path.read_text().strip().split("\n")) > 3
+            assert len(output_path.read_text().strip().split("\n")) >= 3

--- a/src/waddle/processor.py
+++ b/src/waddle/processor.py
@@ -197,7 +197,7 @@ def postprocess_multi_files(
         shutil.rmtree(output_dir_path, ignore_errors=True)
     output_dir_path.mkdir(parents=True, exist_ok=True)
 
-    def process_file(audio_file_path: Path):
+    for audio_file_path in audio_file_paths:
         tmp_audio_file_path = output_dir_path / audio_file_path.name
         if ss > 0 or out_duration:
             clip_audio(audio_file_path, tmp_audio_file_path, ss=ss, out_duration=out_duration)
@@ -213,9 +213,6 @@ def postprocess_multi_files(
             transcription_path,
             whisper_options=whisper_options,
         )
-
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        executor.map(process_file, audio_file_paths)
 
     transcription_output_path = output_dir_path / "transcription.srt"
     combine_srt_files(output_dir_path, transcription_output_path)


### PR DESCRIPTION
This PR updates postprocess to call Whisper in batches rather than processing files individually. By reducing process creation overhead, this change results in approximately a 15% speedup (tested on Mac with the Metal backend—benchmark results below).

Additionally, since whisper.cpp now manages parallelism, configuring concurrency parameters (i.e., -t) becomes more straightforward—you simply specify the number of cores to utilize, regardless of the number of input audio files.

<details>
<summary>Benchmark</summary>

```
waddle on  main is 📦 v0.1.0 via 🐍 v3.12.9 (waddle) took 1m4s 
❯ git checkout main
Already on 'main'
Your branch is up to date with 'origin/main'.

waddle on  main is 📦 v0.1.0 via 🐍 v3.12.9 (waddle) 
❯ time waddle postprocess -d '/Users/shun/Downloads/011/edited' -t 600 -wo "-l ja"
[INFO] Postprocessing audio files from: /Users/shun/Downloads/011/edited
[INFO] Detecting speech segments: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1200/1200 [00:00<00:00, 13259.55it/s]
[INFO] Detecting speech segments: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1200/1200 [00:00<00:00, 15040.63it/s]
[INFO] Global normalization applied with gain adjustment: 2.112532950841924 dB
[INFO] Global normalization applied with gain adjustment: 0.955999641353678 dB
[INFO] Transcribing 51 segments: 100%|██████████████████████████████████████████████████| 51/51 [01:51<00:00,  2.20s/it]
[INFO] Transcribing 42 segments: 100%|██████████████████████████████████████████████████| 42/42 [02:11<00:00,  3.12s/it]
[INFO] Postprocessing complete. Output saved in: out

________________________________________________________
Executed in  132.48 secs    fish           external
   usr time   36.50 secs    0.08 millis   36.50 secs
   sys time   80.11 secs    1.61 millis   80.10 secs


waddle on  main is 📦 v0.1.0 via 🐍 v3.12.9 (waddle) took 2m12s 
❯ git checkout feat/batch-transcribe 
Switched to branch 'feat/batch-transcribe'
Your branch is up to date with 'origin/feat/batch-transcribe'.

waddle on  feat/batch-transcribe is 📦 v0.1.0 via 🐍 v3.12.9 (waddle) 
❯ time waddle postprocess -d '/Users/shun/Downloads/011/edited' -t 600 -wo "-l ja"
[INFO] Postprocessing audio files from: /Users/shun/Downloads/011/edited
[INFO] Detecting speech segments: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1200/1200 [00:00<00:00, 19487.17it/s]
[INFO] Global normalization applied with gain adjustment: 0.955999641353678 dB
[INFO] Detecting speech segments: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1200/1200 [00:00<00:00, 19475.78it/s]
[INFO] Global normalization applied with gain adjustment: 2.112532950841924 dB
[INFO] Postprocessing complete. Output saved in: out

________________________________________________________
Executed in  111.98 secs    fish           external
   usr time   12.75 secs    0.06 millis   12.75 secs
   sys time    7.98 secs    1.36 millis    7.98 secs


```
</details>