### PR TITLE
Refactor argparse: unify common arguments across subcommands

### DIFF
--- a/src/waddle/argparse.py
+++ b/src/waddle/argparse.py
@@ -111,7 +111,10 @@ def create_waddle_parser():
         "--comp-duration",
         type=float,
         default=DEFAULT_COMP_AUDIO_DURATION,
-        help=f"Duration in seconds for alignment comparison (default: {DEFAULT_COMP_AUDIO_DURATION}s).",
+        help=(
+            "Duration in seconds for alignment comparison "
+            f"(default: {DEFAULT_COMP_AUDIO_DURATION}s)."
+        ),
     )
     preprocess_parser.add_argument(
         "-nc",

--- a/src/waddle/argparse.py
+++ b/src/waddle/argparse.py
@@ -5,62 +5,101 @@ from waddle.utils import phrase_time_to_seconds
 
 
 def create_waddle_parser():
-    parser = argparse.ArgumentParser(exit_on_error=False)
+    """
+    Create a command-line argument parser for the Waddle audio processing tool.
 
+    The parser supports three subcommands:
+    - single: Process a single audio file
+    - preprocess: Preprocess multiple audio files
+    - postprocess: Postprocess multiple audio files
+
+    Returns:
+        argparse.ArgumentParser: Configured argument parser
+    """
+    parser = argparse.ArgumentParser(exit_on_error=False)
     subparsers = parser.add_subparsers(dest="subcommand", required=True)
 
+    # Create subparsers with descriptions
     single_parser = subparsers.add_parser(
         "single",
-        description="Process a single audio file: normalize, detect speech, and transcribe.",
+        description=(
+            "Process a single audio file: "
+            "noise removal, normalize, silence removal, and transcription."
+        ),
     )
+    preprocess_parser = subparsers.add_parser(
+        "preprocess",
+        description=(
+            "Preprocess audio files: align audios, remove noise, normalize, and silence removal."
+        ),
+    )
+    postprocess_parser = subparsers.add_parser(
+        "postprocess",
+        description="Postprocess audio files: silence removal, merge, and transcription.",
+    )
+
+    # ===== PRIMARY INPUT ARGUMENTS =====
+    # Add single parser's input argument
     single_parser.add_argument(
         "audio",
         help="Path to the single audio file to process.",
     )
-    single_parser.add_argument(
-        "-o",
-        "--output",
-        default="./out",
-        help="Directory to save the output (default: './out').",
-    )
-    single_parser.add_argument(
-        "-ss",
-        type=phrase_time_to_seconds,
-        default=0.0,
-        help="Start time in seconds for the audio segment (default: None).",
-    )
-    single_parser.add_argument(
-        "-t",
-        "--time",
-        type=phrase_time_to_seconds,
-        default=None,
-        help="Duration in seconds for the output audio (default: None).",
-    )
-    single_parser.add_argument(
-        "--no-noise-remove",
-        action="store_true",
-        help="Skip removing noise from the audio.",
-    )
-    single_parser.add_argument(
-        "-wo",
-        "--whisper-options",
-        default=f"-l {DEFAULT_LANGUAGE}",
-        help=(
-            "Options to pass to Whisper transcription (default: '-l {DEFAULT_LANGUAGE}').\n"
-            "You can change the default language by modifying src/config.py."
-        ),
-    )
 
-    preprocess_parser = subparsers.add_parser(
-        "preprocess",
-        description="Preprocess audio files.",
-    )
-    preprocess_parser.add_argument(
-        "-d",
-        "--directory",
-        default="./",
-        help="Directory containing audio files (used in multi-file mode, default: './').",
-    )
+    # Add directory input for multi-file operations
+    for p in [preprocess_parser, postprocess_parser]:
+        p.add_argument(
+            "-d",
+            "--directory",
+            default="./",
+            help="Directory containing audio files (default: './').",
+        )
+
+    # ===== COMMON ARGUMENTS FOR ALL PARSERS =====
+    parsers = [single_parser, preprocess_parser, postprocess_parser]
+    for p in parsers:
+        p.add_argument(
+            "-o",
+            "--output",
+            default="./out",
+            help="Directory to save the output (default: './out').",
+        )
+        p.add_argument(
+            "-ss",
+            type=phrase_time_to_seconds,
+            default=0.0,
+            help="Start time in seconds for the audio segment (default: 0.0).",
+        )
+        p.add_argument(
+            "-t",
+            "--time",
+            type=phrase_time_to_seconds,
+            default=None,
+            help="Duration in seconds for the output audio (default: None).",
+        )
+
+    # ===== OTHER OPTIONS =====
+    # Noise removal (for audio preprocessing)
+    for p in [single_parser, preprocess_parser]:
+        p.add_argument(
+            "-nnr",
+            "--no-noise-remove",
+            action="store_true",
+            help="Skip removing noise from the audio.",
+        )
+
+    # Whisper transcription options
+    for p in [single_parser, postprocess_parser]:
+        p.add_argument(
+            "-wo",
+            "--whisper-options",
+            default=f"-l {DEFAULT_LANGUAGE}",
+            help=(
+                f"Options to pass to Whisper transcription (default: '-l {DEFAULT_LANGUAGE}').\n"
+                "You can change the default language by modifying src/config.py."
+            ),
+        )
+
+    # preprocess options
     preprocess_parser.add_argument(
         "-r",
         "--reference",
@@ -68,83 +107,17 @@ def create_waddle_parser():
         help="Path to the reference audio file (used in multi-file mode).",
     )
     preprocess_parser.add_argument(
-        "-o",
-        "--output",
-        default=None,
-        help=(
-            "Path to save the output. For single-file mode, this is the directory to save results. "
-            "For multi-file mode, it is the synthesized audio file path."
-        ),
-    )
-    preprocess_parser.add_argument(
         "-c",
         "--comp-duration",
         type=float,
         default=DEFAULT_COMP_AUDIO_DURATION,
-        help="Duration in seconds for alignment comparison (default: 10s).",
-    )
-    preprocess_parser.add_argument(
-        "-ss",
-        type=phrase_time_to_seconds,
-        default=0.0,
-        help="Start time in seconds for the audio segment (default: None).",
-    )
-    preprocess_parser.add_argument(
-        "-t",
-        "--time",
-        type=phrase_time_to_seconds,
-        default=None,
-        help="Duration in seconds for the output audio (default: None).",
-    )
-    preprocess_parser.add_argument(
-        "--no-noise-remove",
-        action="store_true",
-        help="Skip removing noise from the audio.",
+        help=f"Duration in seconds for alignment comparison (default: {DEFAULT_COMP_AUDIO_DURATION}s).",
     )
     preprocess_parser.add_argument(
         "-nc",
         "--no-convert",
         action="store_true",
         help="Skip converting audio files to WAV format.",
-    )
-
-    postprocess_parser = subparsers.add_parser(
-        "postprocess",
-        description="Postprocess audio files: merge and finalize outputs.",
-    )
-    postprocess_parser.add_argument(
-        "-d",
-        "--directory",
-        required=True,
-        help="Directory containing audio files to be postprocessed.",
-    )
-    postprocess_parser.add_argument(
-        "-o",
-        "--output",
-        default="./out",
-        help="Directory to save the postprocessed audio files (default: './out').",
-    )
-    postprocess_parser.add_argument(
-        "-ss",
-        type=phrase_time_to_seconds,
-        default=0.0,
-        help="Start time in seconds for the audio segment (default: None).",
-    )
-    postprocess_parser.add_argument(
-        "-t",
-        "--time",
-        type=phrase_time_to_seconds,
-        default=None,
-        help="Duration in seconds for the output audio (default: None).",
-    )
-    postprocess_parser.add_argument(
-        "-wo",
-        "--whisper-options",
-        default=f"-l {DEFAULT_LANGUAGE}",
-        help=(
-            "Options to pass to Whisper transcription (default: '-l {DEFAULT_LANGUAGE}').\n"
-            "You can change the default language by modifying src/config.py."
-        ),
     )
 
     return parser


### PR DESCRIPTION
- single_parser, preprocess_parser, postprocess_parser: `-o/--output`, `-ss`, `-t/--time`
- single_parser, preprocess_parser: `-nnr/--no-noise-remove`
- single_parser, postprocess_parser: `-wo/--whisper-options`