### PR TITLE
Postprocess bugfix/improvement

### DIFF
--- a/src/waddle/processing/combine.py
+++ b/src/waddle/processing/combine.py
@@ -37,9 +37,8 @@ def combine_segments_into_audio(
         return
 
     if not timeline:
-        start_ms, _ = parse_audio_filename(str(seg_file_paths[0]))
         _, end_ms = parse_audio_filename(str(seg_file_paths[-1]))
-        timeline = [(start_ms, end_ms)]
+        timeline = [(0, end_ms)]
         max_end_ms = end_ms
 
     final_audio = AudioSegment.silent(duration=max_end_ms)

--- a/src/waddle/processor.py
+++ b/src/waddle/processor.py
@@ -214,12 +214,12 @@ def postprocess_multi_files(
             whisper_options=whisper_options,
         )
 
-    transcription_output_path = output_dir_path / "transcription.srt"
-    combine_srt_files(output_dir_path, transcription_output_path)
-
     audio_prefix = audio_file_paths[0].stem
     if "-" in audio_prefix:
         audio_prefix = audio_prefix.split("-")[0]
+
+    transcription_output_path = output_dir_path / f"{audio_prefix}.srt"
+    combine_srt_files(output_dir_path, transcription_output_path)
 
     final_audio_path = output_dir_path / f"{audio_prefix}.wav"
     combined_audio_paths = sorted(output_dir_path.glob("*.wav"))


### PR DESCRIPTION
**Timeline Adjustment for Correct Speaker Alignment**

Currently, postprocess calls combine_segments_into_audio without a timeline, leading to the construction of a dummy timeline in the form of [(t1, t2)], where t1 is the start of the first segment and t2 is the end of the last segment. This results in the first segment being placed at position 0, causing all speakers to start speaking simultaneously when the merged file is played.

This PR updates the function to use [(0, t2)] as the dummy timeline instead, preserving the original segment positions within the generated file.

**Matching Subtitle File Naming to Audio File**

Some audio players automatically associate subtitle files (.srt) with audio files if they share the same base name. This PR ensures that the generated .srt file follows this convention, making it more easily recognized by media players.