### PR TITLE
Rename `remove_noise` function to `deep_filtering`

### DIFF
--- a/src/waddle/audios/call_tools.py
+++ b/src/waddle/audios/call_tools.py
@@ -124,7 +124,7 @@ def ensure_sampling_rate(
 deep_filter_install_lock = threading.Lock()
 
 
-def remove_noise(input_path: Path, output_path: Path) -> None:
+def deep_filtering(input_path: Path, output_path: Path) -> None:
     """
     Enhance audio by removing noise using DeepFilterNet.
     """

--- a/src/waddle/audios/call_tools_test.py
+++ b/src/waddle/audios/call_tools_test.py
@@ -12,8 +12,8 @@ from waddle.audios.call_tools import (
     convert_all_files_to_wav,
     convert_to_mp3,
     convert_to_wav,
+    deep_filtering,
     ensure_sampling_rate,
-    remove_noise,
     transcribe,
     transcribe_in_batches,
 )
@@ -289,7 +289,7 @@ def test_ensure_sampling_rate_error():
                 ensure_sampling_rate(fake_input, output_wav, target_rate=16000)
 
 
-def test_remove_noise():
+def test_deep_filtering():
     """Test noise removal using DeepFilterNet."""
     wav_file_path = EP0_DIR_PATH / "ep12-masa.wav"
     if not wav_file_path.exists():
@@ -302,7 +302,7 @@ def test_remove_noise():
 
         output_wav = temp_dir_path / "denoised.wav"
 
-        remove_noise(temp_wav_path, output_wav)
+        deep_filtering(temp_wav_path, output_wav)
 
         assert output_wav.exists()
         assert get_wav_duration(output_wav) == pytest.approx(
@@ -318,7 +318,7 @@ def test_remove_noise():
         )
 
 
-def test_remove_noise_same_output_path():
+def test_deep_filtering_same_output_path():
     """Test noise removal when input and output paths are the same."""
     wav_file_path = EP0_DIR_PATH / "ep12-masa.wav"
     if not wav_file_path.exists():
@@ -329,7 +329,7 @@ def test_remove_noise_same_output_path():
         wav_path = temp_dir_path / wav_file_path.name
         wav_path.write_bytes(wav_file_path.read_bytes())
 
-        remove_noise(wav_path, wav_path)
+        deep_filtering(wav_path, wav_path)
 
         assert wav_path.exists()
         assert get_wav_duration(wav_path) == pytest.approx(get_wav_duration(wav_file_path), rel=0.1)
@@ -343,19 +343,19 @@ def test_remove_noise_same_output_path():
         )
 
 
-def test_remove_noise_file_not_found():
-    """Test remove_noise when input file does not exist."""
+def test_deep_filtering_file_not_found():
+    """Test deep_filtering when input file does not exist."""
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_dir_path = Path(temp_dir)
         fake_input = temp_dir_path / "non_existent.wav"
         output_wav = temp_dir_path / "output.wav"
 
         with pytest.raises(FileNotFoundError, match="Input file not found"):
-            remove_noise(fake_input, output_wav)
+            deep_filtering(fake_input, output_wav)
 
 
-def test_remove_noise_error():
-    """Test remove_noise when subprocess raises an error."""
+def test_deep_filtering_error():
+    """Test deep_filtering when subprocess raises an error."""
     wav_file_path = EP0_DIR_PATH / "ep12-masa.wav"
     if not wav_file_path.exists():
         pytest.skip(f"Sample file {wav_file_path} not found")
@@ -369,10 +369,10 @@ def test_remove_noise_error():
 
         with subprocess_run_with_error("deep-filter"):
             with pytest.raises(RuntimeError, match="Running DeepFilterNet"):
-                remove_noise(temp_wav_path, output_wav)
+                deep_filtering(temp_wav_path, output_wav)
 
 
-def test_remove_noise_with_missing_deep_filter():
+def test_deep_filtering_with_missing_deep_filter():
     """Test that the DeepFilterNet installation command is executed when the tool is missing."""
     wav_file_path = EP0_DIR_PATH / "ep12-masa.wav"
     if not wav_file_path.exists():
@@ -391,7 +391,7 @@ def test_remove_noise_with_missing_deep_filter():
             patch("waddle.audios.call_tools.get_tools_dir", return_value=temp_dir_path),
         ):
             with pytest.raises(RuntimeError, match="install_deep_filter was called"):
-                remove_noise(temp_wav_path, temp_wav_path)
+                deep_filtering(temp_wav_path, temp_wav_path)
 
 
 def test_transcribe():

--- a/src/waddle/processor.py
+++ b/src/waddle/processor.py
@@ -8,7 +8,7 @@ from waddle.audios.align_offset import align_speaker_to_reference
 from waddle.audios.call_tools import (
     convert_all_files_to_wav,
     convert_to_wav,
-    remove_noise,
+    deep_filtering,
 )
 from waddle.audios.clip import clip_audio
 from waddle.config import DEFAULT_COMP_AUDIO_DURATION, DEFAULT_LANGUAGE
@@ -73,7 +73,7 @@ def process_single_file(
     if ss > 0 or out_duration:
         clip_audio(aligned_audio_path, aligned_audio_path, ss=ss, out_duration=out_duration)
     if not no_noise_remove:
-        remove_noise(aligned_audio_path, aligned_audio_path)
+        deep_filtering(aligned_audio_path, aligned_audio_path)
 
     segs_folder_path, _ = detect_speech_timeline(aligned_audio_path)
 
@@ -147,7 +147,7 @@ def preprocess_multi_files(
         )
         clip_audio(aligned_audio_path, aligned_audio_path, ss=ss, out_duration=out_duration)
         if not no_noise_remove:
-            remove_noise(aligned_audio_path, aligned_audio_path)
+            deep_filtering(aligned_audio_path, aligned_audio_path)
 
         # 2) Preprocess the aligned audio file
         segments_dir, timeline = detect_speech_timeline(aligned_audio_path)


### PR DESCRIPTION
Renamed the `remove_noise` function to `deep_filtering` to better reflect its implementation, as this code calls DeepFilterNet and the DeepFilterNet repository (https://github.com/Rikorose/DeepFilterNet) description states "Noise suppression using deep filtering."

**Reasons for this change:**
- Makes it clear that this function calls DeepFilterNet
- Allows for future implementation of other noise removal functions